### PR TITLE
feat: descriptive test failure messages and JIT response snapshot

### DIFF
--- a/packages/api/src/__tests__/__snapshots__/webhooks.test.ts.snap
+++ b/packages/api/src/__tests__/__snapshots__/webhooks.test.ts.snap
@@ -1,0 +1,11 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`POST /jit-funding response shape matches snapshot 1`] = `
+{
+  "jit_funding": {
+    "amount": 49.99,
+    "method": "pgfs.authorization",
+    "token": "txn_test_001",
+  },
+}
+`;

--- a/packages/api/src/__tests__/escrow.test.ts
+++ b/packages/api/src/__tests__/escrow.test.ts
@@ -12,45 +12,86 @@ beforeEach(() => {
 
 describe("getEscrowBalance", () => {
   it("returns the initial balance", async () => {
-    expect(await getEscrowBalance()).toBe(10_000);
+    const balance = await getEscrowBalance();
+    expect(balance, `initial balance should be $10,000 (got $${balance})`).toBe(
+      10_000
+    );
   });
 });
 
 describe("debitEscrow", () => {
   it("returns true and reduces balance for a valid amount", async () => {
+    const before = await getEscrowBalance();
     const approved = await debitEscrow(250, "txn_001");
-    expect(approved).toBe(true);
-    expect(await getEscrowBalance()).toBe(9_750);
+    const after = await getEscrowBalance();
+    expect(
+      approved,
+      `debit($250): expected approval — escrow was $${before}`
+    ).toBe(true);
+    expect(
+      after,
+      `balance after debit($250) from $${before}: expected $9,750, got $${after}`
+    ).toBe(9_750);
   });
 
   it("returns false and does not change balance when amount exceeds funds", async () => {
+    const before = await getEscrowBalance();
     const approved = await debitEscrow(99_999, "txn_002");
-    expect(approved).toBe(false);
-    expect(await getEscrowBalance()).toBe(10_000);
+    const after = await getEscrowBalance();
+    expect(
+      approved,
+      `debit($99,999) against $${before}: expected rejection (insufficient funds)`
+    ).toBe(false);
+    expect(
+      after,
+      `balance should be unchanged after rejected debit — was $${before}, now $${after}`
+    ).toBe(10_000);
   });
 
   it("allows debiting the exact remaining balance", async () => {
+    const before = await getEscrowBalance();
     const approved = await debitEscrow(10_000, "txn_003");
-    expect(approved).toBe(true);
-    expect(await getEscrowBalance()).toBe(0);
+    const after = await getEscrowBalance();
+    expect(
+      approved,
+      `debit($10,000) equal to full balance $${before}: expected approval`
+    ).toBe(true);
+    expect(
+      after,
+      `balance should be $0 after full escrow debit (was $${before}, now $${after})`
+    ).toBe(0);
   });
 
   it("rejects when balance is zero", async () => {
     await debitEscrow(10_000, "drain");
+    const before = await getEscrowBalance();
     const approved = await debitEscrow(1, "txn_004");
-    expect(approved).toBe(false);
+    expect(
+      approved,
+      `debit($1) against empty escrow ($${before}): expected rejection`
+    ).toBe(false);
   });
 });
 
 describe("creditEscrow", () => {
   it("increases the balance", async () => {
+    const before = await getEscrowBalance();
     await creditEscrow(500, "settlement_001");
-    expect(await getEscrowBalance()).toBe(10_500);
+    const after = await getEscrowBalance();
+    expect(
+      after,
+      `balance after credit($500) to $${before}: expected $10,500, got $${after}`
+    ).toBe(10_500);
   });
 
   it("can replenish after a debit", async () => {
     await debitEscrow(1_000, "txn_005");
+    const afterDebit = await getEscrowBalance();
     await creditEscrow(1_000, "settlement_002");
-    expect(await getEscrowBalance()).toBe(10_000);
+    const after = await getEscrowBalance();
+    expect(
+      after,
+      `balance after credit($1,000) to $${afterDebit}: expected $10,000, got $${after}`
+    ).toBe(10_000);
   });
 });

--- a/packages/api/src/__tests__/health.test.ts
+++ b/packages/api/src/__tests__/health.test.ts
@@ -4,18 +4,35 @@ import health from "../routes/health.js";
 describe("GET /health", () => {
   it("returns 200", async () => {
     const res = await health.request("/");
-    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(
+      res.status,
+      `expected HTTP 200, got ${res.status}; body: ${body}`
+    ).toBe(200);
   });
 
   it("returns status ok", async () => {
     const res = await health.request("/");
-    const body = await res.json() as unknown as { status: string; timestamp: string };
-    expect(body.status).toBe("ok");
+    const body = await res.json() as unknown as {
+      status: string;
+      timestamp: string;
+    };
+    expect(
+      body.status,
+      `expected status "ok", got "${body.status}"; full body: ${JSON.stringify(body)}`
+    ).toBe("ok");
   });
 
   it("returns a valid ISO timestamp", async () => {
     const res = await health.request("/");
-    const body = await res.json() as unknown as { status: string; timestamp: string };
-    expect(new Date(body.timestamp).toString()).not.toBe("Invalid Date");
+    const body = await res.json() as unknown as {
+      status: string;
+      timestamp: string;
+    };
+    const parsed = new Date(body.timestamp);
+    expect(
+      parsed.toString(),
+      `timestamp "${body.timestamp}" is not a valid ISO date`
+    ).not.toBe("Invalid Date");
   });
 });

--- a/packages/api/src/__tests__/webhooks.test.ts
+++ b/packages/api/src/__tests__/webhooks.test.ts
@@ -11,12 +11,32 @@ function makeRequest(body: JitFundingRequest): Request {
   });
 }
 
+/** Read the full response text and parse it, so both are available for
+ *  diagnostic messages without consuming the body twice. */
+async function readResponse(
+  res: Response
+): Promise<{ status: number; text: string; body: unknown }> {
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { status: res.status, text, body };
+}
+
 const basePayload: JitFundingRequest = {
   transaction_token: "txn_test_001",
   card_token: "card_abc",
   amount: 49.99,
   currency_code: "USD",
-  merchant: { name: "Coffee Shop", city: "Austin", country: "US", mcc: "5812" },
+  merchant: {
+    name: "Coffee Shop",
+    city: "Austin",
+    country: "US",
+    mcc: "5812",
+  },
 };
 
 beforeEach(() => {
@@ -25,37 +45,74 @@ beforeEach(() => {
 
 describe("POST /jit-funding", () => {
   it("approves a transaction within escrow balance", async () => {
-    const res = await webhooks.request(makeRequest(basePayload));
-    expect(res.status).toBe(200);
+    const { status, text } = await readResponse(
+      await webhooks.request(makeRequest(basePayload))
+    );
+    expect(
+      status,
+      `expected 200 for $${basePayload.amount} charge; body: ${text}`
+    ).toBe(200);
   });
 
   it("returns the transaction token in the response", async () => {
-    const res = await webhooks.request(makeRequest(basePayload));
-    const body = await res.json() as unknown as JitFundingResponse;
-    expect(body.jit_funding.token).toBe("txn_test_001");
+    const { text, body } = await readResponse(
+      await webhooks.request(makeRequest(basePayload))
+    );
+    const jit = (body as JitFundingResponse).jit_funding;
+    expect(
+      jit.token,
+      `expected token "txn_test_001", got "${jit.token}"; body: ${text}`
+    ).toBe("txn_test_001");
   });
 
   it("echoes back the authorized amount", async () => {
-    const res = await webhooks.request(makeRequest(basePayload));
-    const body = await res.json() as unknown as JitFundingResponse;
-    expect(body.jit_funding.amount).toBe(49.99);
+    const { text, body } = await readResponse(
+      await webhooks.request(makeRequest(basePayload))
+    );
+    const jit = (body as JitFundingResponse).jit_funding;
+    expect(
+      jit.amount,
+      `expected amount ${basePayload.amount}, got ${jit.amount}; body: ${text}`
+    ).toBe(49.99);
+  });
+
+  it("response shape matches snapshot", async () => {
+    const { body } = await readResponse(
+      await webhooks.request(makeRequest(basePayload))
+    );
+    expect(body).toMatchSnapshot();
   });
 
   it("declines a transaction that exceeds escrow balance", async () => {
-    const res = await webhooks.request(
-      makeRequest({ ...basePayload, amount: 999_999 })
+    const { status, text } = await readResponse(
+      await webhooks.request(makeRequest({ ...basePayload, amount: 999_999 }))
     );
-    expect(res.status).toBe(402);
+    expect(
+      status,
+      `expected 402 for $999,999 charge against $10,000 escrow; body: ${text}`
+    ).toBe(402);
   });
 
   it("sequential approvals reduce the escrow correctly", async () => {
     await webhooks.request(makeRequest({ ...basePayload, amount: 100 }));
     await webhooks.request(makeRequest({ ...basePayload, amount: 200 }));
+
     // 100 + 200 + 9_700 = 10_000 — fully drains the escrow
-    const res = await webhooks.request(makeRequest({ ...basePayload, amount: 9_700 }));
-    expect(res.status).toBe(200);
-    // escrow is now zero — any further charge should be declined
-    const declined = await webhooks.request(makeRequest({ ...basePayload, amount: 0.01 }));
-    expect(declined.status).toBe(402);
+    const { status: s1, text: t1 } = await readResponse(
+      await webhooks.request(makeRequest({ ...basePayload, amount: 9_700 }))
+    );
+    expect(
+      s1,
+      `third charge ($9,700) should be approved (100+200+9700=$10,000); body: ${t1}`
+    ).toBe(200);
+
+    // escrow is now $0 — any further charge should be declined
+    const { status: s2, text: t2 } = await readResponse(
+      await webhooks.request(makeRequest({ ...basePayload, amount: 0.01 }))
+    );
+    expect(
+      s2,
+      `charge after escrow fully drained should be declined; body: ${t2}`
+    ).toBe(402);
   });
 });


### PR DESCRIPTION
Closes #2

## Summary

- **Escrow tests** — every `expect()` now captures balance before/after the operation and embeds it in the failure message. A failing debit assertion reads like `"debit($250): expected approval — escrow was $10,000"` rather than `"expected false to be true"`
- **Health tests** — reads full response body text before asserting; timestamp failure message includes the raw value that failed to parse
- **Webhook tests** — new `readResponse()` helper reads the body once and exposes `status`, raw `text`, and parsed `body` so every assertion can include the full payload on failure. Each status-code check names the charge amount and escrow context
- **Snapshot** — `toMatchSnapshot()` test locks the full JIT funding response shape; any structural regression (renamed field, missing key) will immediately surface with a diff

## Test plan

- [x] `bun test` — 18/18 pass, 1 snapshot written
- [x] Intentionally break a field name in `webhooks.ts` and confirm the snapshot test fails with a readable diff
- [x] Intentionally break `debitEscrow` and confirm the failure message includes the balance context

🤖 Generated with [Claude Code](https://claude.com/claude-code)