### PR TITLE
fix: add changelog automation missed from PR #5 merge

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,12 +43,35 @@ jobs:
           NEW=$(python3 scripts/bump_version.py ${{ steps.bump-type.outputs.type }})
           echo "version=$NEW" >> "$GITHUB_OUTPUT"
 
+      - name: Stamp CHANGELOG and reset [Unreleased]
+        run: |
+          python3 - <<'PYEOF'
+          from datetime import date
+          from pathlib import Path
+
+          version = "${{ steps.version.outputs.version }}"
+          today = date.today().isoformat()
+          path = Path("CHANGELOG.md")
+          text = path.read_text()
+
+          # Replace the first [Unreleased] header with:
+          #   ## [Unreleased]          <- empty, ready for next cycle
+          #
+          #   ## [vX.Y.Z] - YYYY-MM-DD  <- stamped release
+          stamped = text.replace(
+              "## [Unreleased]",
+              f"## [Unreleased]\n\n## [{version}] - {today}",
+              1,
+          )
+          path.write_text(stamped)
+          PYEOF
+
       - name: Commit version bump & tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email \
             "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json
+          git add package.json CHANGELOG.md
           git commit \
             -m "chore: release v${{ steps.version.outputs.version }} [skip ci]"
           git tag -a "v${{ steps.version.outputs.version }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to SolCard are documented here.
+Entries are short — one line per logical change.
+
+## [Unreleased]
+
+- Add `scripts/update_changelog.py` to auto-generate changelog entries via Claude API
+- Add CD workflow step to auto-update `CHANGELOG.md` on every commit
+- Update `scripts/setup_hooks.py` to support changelog automation hook
+- Add CD workflow step to auto-update `README.md` via Claude API on every commit
+
+## [2026.1.2] - 2026-02-22
+
+- Add `dev` branch as permanent integration branch
+- Add `main` branch as production-only branch
+- Add `year.proud_patch.small_patch` versioning scheme
+- Add `scripts/bump_version.py` for manual version bumping
+- Add CD workflow to auto-bump version and tag on merge to `main`
+- Add CD workflow step to sync `main` back into `dev` after every release
+- Add `CONTRIBUTING.md` with branching strategy, versioning, and PR checklist
+- Update CI workflow to also gate PRs targeting `dev`
+
+## [2026.1.1] - 2026-02-22
+
+- Add Bun monorepo with `packages/api` (Hono) and `packages/web` (React + Vite + Tailwind)
+- Add Marqeta JIT funding webhook stub (`POST /webhooks/jit-funding`)
+- Add in-memory escrow ledger with debit, credit, and balance operations
+- Add Solana RPC integration for wallet balance and stake account queries
+- Add pre-commit hook that runs `bun test` and `bun run lint` before every commit
+- Add GitHub Actions CI pipeline (test + type check on every push and PR)
+- Add descriptive test failure messages with balance context and snapshot for JIT response shape
+- Add `scripts/setup_hooks.py` to install git hooks after clone
+- Add `scripts/update_license_year.py` to auto-update LICENSE year on commit
+- Add `ci/pre-commit.sh` as standalone CI gate script
+- Add `docs/architecture.md` and `docs/card-flow.md`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ solcard/
 ├── scripts/
 │   ├── setup_hooks.py          # Installs git pre-commit hook
 │   ├── bump_version.py         # Manual version bump utility
+│   ├── update_changelog.py     # Changelog tooling
 │   ├── update_license_year.py  # Auto-updates LICENSE year on commit
 │   └── update_readme.py        # README tooling
 ├── docs/
@@ -69,6 +70,7 @@ solcard/
 ├── .env.example
 ├── tsconfig.base.json
 ├── CONTRIBUTING.md
+├── CHANGELOG.md
 └── package.json
 ```
 
@@ -219,7 +221,7 @@ Called by Marqeta when a card is swiped. Must respond within ~5 seconds. Debits 
 
 ## Escrow (Current State)
 
-The escrow module (`packages/api/src/lib/escrow.ts`) is an in-memory stub with a fixed starting balance of `$10,000 USD`. It exposes three operations:
+The escrow module (`packages/api/src/lib/escrow.ts`) is an in-memory stub with a fixed starting balance of `$10,000 USD`. It exposes four operations:
 
 | Function | Description |
 | --- | --- |

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -22,7 +22,8 @@ export PATH="$HOME/.bun/bin:$PATH"
 "$ROOT/ci/pre-commit.sh" || exit 1
 python3 "$ROOT/scripts/update_license_year.py"
 python3 "$ROOT/scripts/update_readme.py"
-git add "$ROOT/LICENSE" "$ROOT/README.md"
+python3 "$ROOT/scripts/update_changelog.py"
+git add "$ROOT/LICENSE" "$ROOT/README.md" "$ROOT/CHANGELOG.md"
 """
 
 

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Auto-update CHANGELOG.md using the Claude API.
+
+On each commit, reads the staged diff summary and recent git history,
+then asks Claude to add concise bullet points to the [Unreleased]
+section. Bullets are short — one line per logical change.
+
+The CD workflow (cd.yml) stamps [Unreleased] with the release version
+and resets the section to empty on every merge to main.
+
+Usage (called automatically by the pre-commit hook):
+    python3 scripts/update_changelog.py
+
+Exits cleanly without blocking the commit if CLAUDE_API_KEY is absent
+or the API call fails.
+"""
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MODEL = "claude-sonnet-4-6"
+CHANGELOG = ROOT / "CHANGELOG.md"
+
+
+def load_env() -> dict[str, str]:
+    """Load variables from .env then .env.local (.env.local wins)."""
+    env: dict[str, str] = {}
+    for name in (".env", ".env.local"):
+        path = ROOT / name
+        if not path.exists():
+            continue
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            env[k.strip()] = v.strip()
+    return env
+
+
+def _run(cmd: list[str]) -> str:
+    result = subprocess.run(
+        cmd, cwd=ROOT, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def staged_summary() -> str:
+    """Files changed in the current staged commit."""
+    return _run(["git", "diff", "--cached", "--stat"])
+
+
+def recent_commits() -> str:
+    """Commits since last tag, or last 10 if no tags exist."""
+    last_tag = _run(["git", "describe", "--tags", "--abbrev=0"])
+    if last_tag:
+        return _run(["git", "log", f"{last_tag}..HEAD", "--oneline"])
+    return _run(["git", "log", "--oneline", "-10"])
+
+
+def ensure_changelog() -> str:
+    """Return current CHANGELOG content, creating it if missing."""
+    if not CHANGELOG.exists():
+        CHANGELOG.write_text(
+            "# Changelog\n\n"
+            "All notable changes to SolCard are documented here.\n"
+            "Entries are short — one line per logical change.\n\n"
+            "## [Unreleased]\n"
+        )
+    return CHANGELOG.read_text()
+
+
+def _strip_outer_fence(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines[-1].strip() == "```":
+            return "\n".join(lines[1:-1]).strip()
+    return stripped
+
+
+def call_claude(api_key: str, current: str, context: str) -> str:
+    """Ask Claude to add concise bullets to [Unreleased]."""
+    prompt = "\n".join([
+        "You are maintaining CHANGELOG.md for the SolCard project.",
+        "Format follows Keep a Changelog (keepachangelog.com).",
+        "",
+        "Given the staged file summary and recent commits below, update",
+        "the [Unreleased] section with concise bullet points for this",
+        "commit. Rules:",
+        "- Each bullet is one short sentence (max ~80 chars)",
+        "- Start each bullet with a verb: Add, Fix, Update, Remove, etc.",
+        "- Do not duplicate bullets already present in [Unreleased]",
+        "- Do not add or modify version headers — only edit [Unreleased]",
+        "- Do not include dates, authors, or commit hashes",
+        "- Skip trivial housekeeping (whitespace fixes, comment typos)",
+        "",
+        "Current CHANGELOG.md:",
+        "```",
+        current.strip(),
+        "```",
+        "",
+        "Context (staged changes + recent commits):",
+        context,
+        "",
+        "Output ONLY the complete updated CHANGELOG.md — no explanation.",
+    ])
+
+    payload = json.dumps({
+        "model": MODEL,
+        "max_tokens": 2048,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode()
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read())
+    return _strip_outer_fence(data["content"][0]["text"])
+
+
+def main() -> None:
+    env = load_env()
+    api_key = env.get("CLAUDE_API_KEY") or os.environ.get(
+        "CLAUDE_API_KEY", ""
+    )
+    if not api_key:
+        print(
+            "update_changelog: CLAUDE_API_KEY not set"
+            " — skipping changelog update"
+        )
+        return
+
+    staged = staged_summary()
+    if not staged:
+        # Nothing staged — no meaningful entry to add
+        return
+
+    current = ensure_changelog()
+    commits = recent_commits()
+    context = (
+        f"Staged changes:\n{staged}\n\nRecent commits:\n{commits}"
+    )
+
+    print("Updating CHANGELOG.md via Claude API...")
+    try:
+        updated = call_claude(api_key, current, context)
+        updated = _strip_outer_fence(updated)
+    except (urllib.error.URLError, KeyError, json.JSONDecodeError) as exc:
+        print(f"update_changelog: API call failed ({exc}) — skipping")
+        return
+
+    CHANGELOG.write_text(updated + "\n")
+    print("CHANGELOG.md updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The CHANGELOG.md commit (`80d2406`) was pushed to `feat/auto-readme-update` after PR #5 was already merged, so it never landed on `dev`. This cherry-picks it in.

**What's included:**
- `scripts/update_changelog.py` — calls Claude to add concise bullets to `[Unreleased]` on each commit
- `CHANGELOG.md` — initial file with `[Unreleased]` section and historical entries for `2026.1.1` and `2026.1.2`
- `scripts/setup_hooks.py` — hook now calls `update_changelog.py` and stages `CHANGELOG.md`
- `.github/workflows/cd.yml` — stamps `[Unreleased]` → `[vX.Y.Z]` and resets it to empty on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)